### PR TITLE
MOB-536: Allow to add new Connections

### DIFF
--- a/me.id.webverify/app/src/main/res/layout/activity_main.xml
+++ b/me.id.webverify/app/src/main/res/layout/activity_main.xml
@@ -10,62 +10,88 @@
     tools:context=".MainActivity"
     >
 
+    <LinearLayout
+        android:id="@+id/linearLayout_actions"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center_horizontal"
+        android:layout_alignParentBottom="true"
+        >
+
+        <Button
+            android:id="@+id/btnLogin"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/login"
+            />
+
+        <Spinner
+            android:id="@+id/spnProperties"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:drawSelectorOnTop="true"
+            android:entries="@array/boolean_array"
+            android:layout_marginTop="10dp"
+            />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@android:color/darker_gray"
+            android:layout_marginTop="10dp"
+            />
+
+        <Spinner
+            android:id="@+id/spnAffiliation"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:drawSelectorOnTop="true"
+            android:entries="@array/affiliations"
+            android:layout_marginTop="10dp"
+            />
+
+        <Button
+            android:id="@+id/btnAddAffiliation"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="@string/add_affiliation"
+            />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@android:color/darker_gray"
+            android:layout_marginTop="10dp"
+            />
+
+        <Spinner
+            android:id="@+id/spnConnection"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:drawSelectorOnTop="true"
+            android:entries="@array/connections"
+            android:layout_marginTop="10dp"
+            />
+
+        <Button
+            android:id="@+id/btnAddConnection"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="@string/add_connection"
+            />
+
+    </LinearLayout>
+
     <TextView
         android:id="@+id/txtResult"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/result_text"
-        />
-
-    <Spinner
-        android:id="@+id/spnRoute"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:drawSelectorOnTop="true"
-        android:entries="@array/array_name"
-        android:layout_alignParentBottom="true"
-        android:layout_centerHorizontal="true"
-        android:layout_marginBottom="203dp"
-        />
-
-    <View
-        android:id="@+id/divider"
         android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@android:color/darker_gray"
-        android:layout_alignTop="@id/spnRoute"
-        android:layout_marginTop="-10dp"
-        />
-
-    <Button
-        android:id="@+id/btnLogin"
-        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignBottom="@id/divider"
-        android:layout_centerHorizontal="true"
-        android:layout_marginBottom="10dp"
-        android:text="@string/login"
-        />
-
-    <Spinner
-        android:id="@+id/spnProperties"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:drawSelectorOnTop="true"
-        android:entries="@array/boolean_array"
-        android:layout_alignParentBottom="true"
-        android:layout_centerHorizontal="true"
-        android:layout_marginBottom="163dp"
-        />
-
-    <Button
-        android:id="@+id/btnVerify"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignTop="@+id/spnProperties"
-        android:layout_centerHorizontal="true"
-        android:layout_marginTop="68dp"
-        android:text="@string/verify_me"
+        android:layout_alignTop="@id/linearLayout_actions"
+        android:layout_alignParentTop="true"
+        android:text="@string/result_text"
         />
 
 </RelativeLayout>

--- a/me.id.webverify/app/src/main/res/values/strings.xml
+++ b/me.id.webverify/app/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <string name="result_text">Respone:</string>
     <string name="action_settings">Settings</string>
 
-    <string-array name="array_name">
+    <string-array name="affiliations">
         <item>Military</item>
         <item>Student</item>
         <item>Teacher</item>
@@ -13,13 +13,22 @@
         <item>Government</item>
     </string-array>
 
+    <string-array name="connections">
+        <item>DSLogon</item>
+        <item>Facebook</item>
+        <item>Google</item>
+        <item>Linkedin</item>
+        <item>Paypal</item>
+    </string-array>
+
     <string-array name="boolean_array">
         <item>Yes</item>
         <item>No</item>
     </string-array>
 
+    <string name="add_affiliation">Add Affiliation</string>
+    <string name="add_connection">Add Connection</string>
     <string name="title_activity_web_view">WebView</string>
-    <string name="verify_me">Verify Me</string>
     <string name="login">Login</string>
 
 </resources>

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/IDmeConnectionType.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/IDmeConnectionType.java
@@ -1,0 +1,23 @@
+package me.id.webverifylib;
+
+/**
+ * Created by remer on 6/2/17.
+ */
+public enum IDmeConnectionType {
+  DS_LOGON("dslogon"),
+  FACEBOOK("facebook"),
+  GOOGLE_PLUS("google"),
+  LINEDIN("linkedin"),
+  PAYPAL("paypal"),
+  ;
+
+  private final String key;
+
+  IDmeConnectionType(String key) {
+    this.key = key;
+  }
+
+  public String getKey() {
+    return key;
+  }
+}

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/IDmeRegisterConnectionListener.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/IDmeRegisterConnectionListener.java
@@ -1,0 +1,9 @@
+package me.id.webverifylib;
+
+/**
+ * Created by remer on 6/2/17.
+ */
+public interface IDmeRegisterConnectionListener {
+  void onSuccess();
+  void onError(Throwable throwable);
+}

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RegisterConnectionFinishedListener.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RegisterConnectionFinishedListener.java
@@ -1,0 +1,21 @@
+package me.id.webverifylib;
+
+/**
+ * Created by remer on 6/2/17.
+ */
+class RegisterConnectionFinishedListener extends PageFinishedListener {
+  RegisterConnectionFinishedListener(IDmeWebVerify webVerify, String redirectUrl) {
+    super(webVerify, redirectUrl);
+  }
+
+  @Override
+  public void onCallbackResponse(String responseUrl, IDmeScope scope) {
+    super.onCallbackResponse(responseUrl, scope);
+    String error = errorFromResponseUrl(responseUrl);
+    if (error == null) {
+      getWebVerify().notifyConnectionRegistration();
+    } else {
+      getWebVerify().notifyFailure(new RuntimeException(error));
+    }
+  }
+}

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/WebViewActivity.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/WebViewActivity.java
@@ -62,9 +62,9 @@ public class WebViewActivity extends AppCompatActivity {
   @Override
   public void onBackPressed() {
     if (webView.canGoBack()) {
-      IDmeWebVerify.getInstance().notifyFailure(new Exception("Canceled by the user"));
       webView.goBack();
     } else {
+      IDmeWebVerify.getInstance().notifyFailure(new RuntimeException("Canceled by the user"));
       super.onBackPressed();
     }
   }


### PR DESCRIPTION
* [MOB-536: [Android] ID.me WebVerify SDK - API for adding a new Login (connection)](https://idmeinc.atlassian.net/secure/RapidBoard.jspa?rapidView=127&projectKey=MOB&view=planning&selectedIssue=MOB-536)

## Description
Added a new function that allow developers to add new connections to a signed in user. This function takes an scope to search for a local auth token before it starts the registration process. Additionally this function receives an activity in order to start the web view activity and the connection type which will be added to the user's account.

## Changes proposed in this request:
* Added new function `registerAffiliation`
* Refactored layout `activity_main.xml` in the example project
   - Moved all the actions and spinners to a vertical linear layout
* Fixed issue where the listener's `onError` function wasn't called if the web view activity was closed by touching the back button.

## Contains
- [ ] Tests
- [ ] Documentation

Assigned to @reviewer
