### PR TITLE
MOB-553: remove DS Logon from supported connection types

### DIFF
--- a/me.id.webverify/app/src/main/java/me/id/meidwebverify/MainActivity.java
+++ b/me.id.webverify/app/src/main/java/me/id/meidwebverify/MainActivity.java
@@ -163,9 +163,7 @@ public class MainActivity extends ActionBarActivity {
       return null;
     } else {
       String selectedItemText = selectedItem.toString().toLowerCase();
-      if (selectedItemText.equals(IDmeConnectionType.DS_LOGON.getKey().toLowerCase())) {
-        return IDmeConnectionType.DS_LOGON;
-      } else if (selectedItemText.equals(IDmeConnectionType.FACEBOOK.getKey().toLowerCase())) {
+      if (selectedItemText.equals(IDmeConnectionType.FACEBOOK.getKey().toLowerCase())) {
         return IDmeConnectionType.FACEBOOK;
       } else if (selectedItemText.equals(IDmeConnectionType.GOOGLE_PLUS.getKey().toLowerCase())) {
         return IDmeConnectionType.GOOGLE_PLUS;

--- a/me.id.webverify/app/src/main/res/values/strings.xml
+++ b/me.id.webverify/app/src/main/res/values/strings.xml
@@ -14,7 +14,6 @@
     </string-array>
 
     <string-array name="connections">
-        <item>DSLogon</item>
         <item>Facebook</item>
         <item>Google</item>
         <item>Linkedin</item>

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/IDmeConnectionType.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/IDmeConnectionType.java
@@ -4,7 +4,6 @@ package me.id.webverifylib;
  * Created by remer on 6/2/17.
  */
 public enum IDmeConnectionType {
-  DS_LOGON("dslogon"),
   FACEBOOK("facebook"),
   GOOGLE_PLUS("google"),
   LINEDIN("linkedin"),


### PR DESCRIPTION
[MOB-553: [Android] Remove DS Logon from the supported connection types in the SDK](https://idmeinc.atlassian.net/browse/MOB-553)

## Description
Removed DS Logon from supported connection types

## Changes proposed in this request:
* Removed item `DS_LOGON` from `IDmeConnectionType`

## Contains
- [ ] Tests
- [ ] Documentation
