### PR TITLE
MOB-944: keep browser in stack to take pictures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### UNRELEASED
 
 - MOB-835: Fix refresh token issue
+- MOB-944: keep browser in stack to take pictures
 
 ### v2.0.3 (2017-05-30)
 

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RedirectUriReceiverActivity.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RedirectUriReceiverActivity.java
@@ -1,6 +1,8 @@
 package me.id.webverifylib;
 
 import android.app.Activity;
+import android.app.PendingIntent;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.util.Log;
@@ -59,6 +61,12 @@ public class RedirectUriReceiverActivity extends Activity {
 
   private void sendResult(int resultCode) {
     setResult(resultCode);
+    try {
+      Intent intent = new Intent(this, IDmeCustomTabsActivity.class);
+      PendingIntent.getActivity(this, 0, intent, 0).send();
+    } catch (PendingIntent.CanceledException ex) {
+      ex.printStackTrace();
+    }
     finish();
   }
 }

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RedirectUriReceiverActivity.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RedirectUriReceiverActivity.java
@@ -62,6 +62,9 @@ public class RedirectUriReceiverActivity extends Activity {
   private void sendResult(int resultCode) {
     setResult(resultCode);
     try {
+      // MOB-944: send an intent to the activity that started the browser. This is needed due to 
+      // RedirectUriReceiverActivity is opened in the browser's stack, so when this activity finishes,
+      // the result is that the browser will stay visible.
       Intent intent = new Intent(this, IDmeCustomTabsActivity.class);
       PendingIntent.getActivity(this, 0, intent, 0).send();
     } catch (PendingIntent.CanceledException ex) {

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/helper/CustomTabsHelper.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/helper/CustomTabsHelper.java
@@ -35,7 +35,7 @@ public class CustomTabsHelper {
     if (packageName != null) {
       customTabsIntent.intent.setPackage(packageName);
     }
-    customTabsIntent.intent.setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY | Intent.FLAG_ACTIVITY_CLEAR_TOP
+    customTabsIntent.intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP
         | Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
     return customTabsIntent;
   }


### PR DESCRIPTION
**NOTE FOR REVIEWERS**: just pay attention to the last commit. The other changes are included in the PR #43 

Fix issue [MOB-944](https://idmeinc.atlassian.net/browse/MOB-944)

## Description
As the custom tab browser was opened using the flag `Intent.FLAG_ACTIVITY_NO_HISTORY`, its activity is automatically closed when the camera is opened to take a picture. Removing such flag makes the browser never disappears from the current stack, this is solved by sending an intent to the activity whose started the browser.

## Changes proposed in this request:
* Removed the flag `Intent.FLAG_ACTIVITY_NO_HISTORY` from the intent that opens the custom tab browser.
* Sending an intent to the `IDmeCustomTabsActivity` activity to come back to the app.
