### PR TITLE
MOB-868: send error back instead of throwing if no intent is received

### DIFF
--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/IDmeWebVerify.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/IDmeWebVerify.java
@@ -22,7 +22,8 @@ import me.id.webverifylib.listener.IDmeScope;
 import me.id.webverifylib.networking.GetProfileConnectionTask;
 
 public final class IDmeWebVerify {
-  private static final String TAG = "ID.me";
+  public static final String TAG = "ID.me SDK";
+
   private static final String PARAM_ACCESS_TOKEN = "access_token";
   private static final String PARAM_CLIENT_ID = "client_id";
   private static final String PARAM_CLIENT_SECRET = "client_secret";

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RedirectUriReceiverActivity.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RedirectUriReceiverActivity.java
@@ -27,8 +27,17 @@ public class RedirectUriReceiverActivity extends Activity {
   protected void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     State currentState = IDmeWebVerify.getCurrentState();
+
     if (currentState == null) {
-      throw new IDmeException("Current state cannot be null");
+      IDmeWebVerify.getInstance().notifyFailure(new IDmeException("Current state cannot be null"));
+      sendResult(RESULT_CANCELED);
+      return;
+    }
+
+    if (getIntent() == null || getIntent().getData() == null) {
+      IDmeWebVerify.getInstance().notifyFailure(new IDmeException("Null intent or invalid data was received"));
+      sendResult(RESULT_CANCELED);
+      return;
     }
 
     if (currentState == State.LOGOUT) {

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RedirectUriReceiverActivity.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RedirectUriReceiverActivity.java
@@ -3,12 +3,15 @@ package me.id.webverifylib;
 import android.app.Activity;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.util.Log;
 
 import me.id.webverifylib.exception.IDmeException;
 import me.id.webverifylib.listener.IDmeAccessTokenManagerListener;
 import me.id.webverifylib.networking.GetAccessTokenConnectionTask;
 
 public class RedirectUriReceiverActivity extends Activity {
+  private static final String TAG = "Idme SDK";
+
   private final IDmeAccessTokenManagerListener authCodeListener = new IDmeAccessTokenManagerListener() {
     @Override
     public void onSuccess(AuthToken authToken) {
@@ -29,7 +32,7 @@ public class RedirectUriReceiverActivity extends Activity {
     State currentState = IDmeWebVerify.getCurrentState();
 
     if (currentState == null) {
-      IDmeWebVerify.getInstance().notifyFailure(new IDmeException("Current state cannot be null"));
+      Log.w(TAG, "Activity was created but there is not an initialized process");
       sendResult(RESULT_CANCELED);
       return;
     }

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RedirectUriReceiverActivity.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RedirectUriReceiverActivity.java
@@ -10,8 +10,6 @@ import me.id.webverifylib.listener.IDmeAccessTokenManagerListener;
 import me.id.webverifylib.networking.GetAccessTokenConnectionTask;
 
 public class RedirectUriReceiverActivity extends Activity {
-  private static final String TAG = "Idme SDK";
-
   private final IDmeAccessTokenManagerListener authCodeListener = new IDmeAccessTokenManagerListener() {
     @Override
     public void onSuccess(AuthToken authToken) {
@@ -32,7 +30,7 @@ public class RedirectUriReceiverActivity extends Activity {
     State currentState = IDmeWebVerify.getCurrentState();
 
     if (currentState == null) {
-      Log.w(TAG, "Activity was created but there is not an initialized process");
+      Log.w(IDmeWebVerify.TAG, "Activity was created but there is not an initialized process");
       sendResult(RESULT_CANCELED);
       return;
     }

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/helper/CodeVerifierUtil.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/helper/CodeVerifierUtil.java
@@ -9,6 +9,8 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.regex.Pattern;
 
+import me.id.webverifylib.IDmeWebVerify;
+
 /**
  * Generates code verifiers and challenges for PKCE exchange.
  *
@@ -18,8 +20,6 @@ import java.util.regex.Pattern;
  * <https://tools.ietf.org/html/rfc7636>"
  */
 public class CodeVerifierUtil {
-  private static final String TAG = "Idme SDK";
-
   /**
    * SHA-256 based code verifier challenge method.
    *
@@ -139,7 +139,7 @@ public class CodeVerifierUtil {
       byte[] digestBytes = sha256Digester.digest();
       return Base64.encodeToString(digestBytes, PKCE_BASE64_ENCODE_SETTINGS);
     } catch (NoSuchAlgorithmException e) {
-      Log.d(TAG, "SHA-256 is not supported on this device! Using plain challenge");
+      Log.d(IDmeWebVerify.TAG, "SHA-256 is not supported on this device! Using plain challenge");
       return codeVerifier;
     } catch (UnsupportedEncodingException e) {
       throw new IllegalStateException("ISO-8859-1 encoding not supported", e);

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/helper/ObjectHelper.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/helper/ObjectHelper.java
@@ -15,6 +15,8 @@ import java.io.InputStreamReader;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
+import me.id.webverifylib.IDmeWebVerify;
+
 public final class ObjectHelper {
   private ObjectHelper() {
   }
@@ -103,7 +105,7 @@ public final class ObjectHelper {
         response.append(line);
       }
     } catch (IOException exception) {
-      Log.e("Read stream error", exception.getMessage());
+      Log.e(IDmeWebVerify.TAG, "Read stream error", exception);
     } finally {
       if (reader != null) {
         try {

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/networking/GetProfileConnectionTask.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/networking/GetProfileConnectionTask.java
@@ -14,6 +14,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 
 import me.id.webverifylib.IDmeProfile;
+import me.id.webverifylib.IDmeWebVerify;
 import me.id.webverifylib.exception.IDmeException;
 import me.id.webverifylib.listener.IDmeGetProfileListener;
 
@@ -88,7 +89,7 @@ public final class GetProfileConnectionTask extends AsyncTask<String, Void, Stri
         try {
           reader.close();
         } catch (IOException exception) {
-          Log.e("Read stream error", exception.getMessage());
+          Log.e(IDmeWebVerify.TAG, "Read stream error", exception);
         }
       }
     }


### PR DESCRIPTION
Fix [MOB-868](https://idmeinc.atlassian.net/browse/MOB-868)

## Description
Send an error back if wrong data is passed to the `RedirectUriReceiverActivity` is passed through the intent.

## Changes proposed in this request:
* --
