### PR TITLE
MOB-1029: notify failure if no state was set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - MOB-835: Fix refresh token issue
 - MOB-944: keep browser in stack to take pictures
+- MOB-1029: notify failure if no state was set
 
 ### v2.0.3 (2017-05-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### UNRELEASED
 
 - MOB-835: Fix refresh token issue
+- MOB-944: keep browser in stack to take pictures
 
 ### v2.0.3 (2017-05-30)
 

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/IDmeCustomTabsActivity.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/IDmeCustomTabsActivity.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.net.Uri;
 import android.os.Bundle;
+import android.util.Log;
 
 import me.id.webverifylib.exception.UserCanceledException;
 import me.id.webverifylib.helper.CustomTabsHelper;
@@ -18,6 +19,13 @@ public class IDmeCustomTabsActivity extends Activity {
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     url = getIntent().getStringExtra(EXTRA_URL);
+
+    if (url == null) {
+      // MOB-1029: if coming with not current state, url will be null and crash the app
+      Log.d(IDmeWebVerify.TAG, "Null url value received");
+      finish();
+      return;
+    }
 
     if (savedInstanceState == null) {
       shouldCloseCustomTab = false;

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/IDmePreferences.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/IDmePreferences.java
@@ -1,0 +1,64 @@
+package me.id.webverifylib;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.ApplicationInfo;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+/**
+ * Created by remer on 30/11/17.
+ */
+public class IDmePreferences {
+  private static final String APP_NAME_KEY_NAME = "IDmeWebVerify.applicationName";
+
+  @Nullable
+  private SharedPreferences preferences;
+  @Nullable
+  private AsyncSharedPreferenceLoader preferenceLoader;
+  @NonNull
+  private final Context context;
+
+  public IDmePreferences(Context context) {
+    this.context = context;
+  }
+
+  void storeApplicationNameFromContext(@NonNull Context context) {
+    loadPreferencesIfNeeded(context);
+    if (preferences == null) {
+      return;
+    }
+
+    ApplicationInfo applicationInfo = context.getApplicationInfo();
+    int stringId = applicationInfo.labelRes;
+    String appName = stringId == 0 ? applicationInfo.nonLocalizedLabel.toString() : context.getString(stringId);
+    preferences.edit()
+        .putString(APP_NAME_KEY_NAME, appName)
+        .apply();
+  }
+
+  @Nullable
+  String loadApplicationName(@NonNull Context context) {
+    loadPreferencesIfNeeded(context);
+    if (preferences == null) {
+      return null;
+    }
+
+    return preferences.getString(APP_NAME_KEY_NAME, null);
+  }
+
+  private void loadPreferencesIfNeeded(Context context) {
+    if (preferenceLoader == null) {
+      try {
+        preferenceLoader = new AsyncSharedPreferenceLoader(context);
+      } catch (Exception ex) {
+        Log.w(IDmeWebVerify.TAG, "Failed to load shared preferences", ex);
+        return;
+      }
+    }
+    if (preferences == null) {
+      preferences = preferenceLoader.get();
+    }
+  }
+}

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/IDmeWebVerify.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/IDmeWebVerify.java
@@ -57,15 +57,12 @@ public final class IDmeWebVerify {
   private static boolean initialized;
   private static State currentState;
 
+  private IDmePreferences preferences;
+
   private IDmeGetAccessTokenListener accessTokenCallback = null;
   private IDmeCompletableListener completableCallback = null;
 
   private static final IDmeWebVerify INSTANCE = new IDmeWebVerify();
-
-  @Nullable
-  private SharedPreferences preferences;
-  @Nullable
-  private AsyncSharedPreferenceLoader preferenceLoader;
 
   /**
    * This method needs to be called before IDmeWebVerify can be used.
@@ -101,54 +98,19 @@ public final class IDmeWebVerify {
     IDmeWebVerify.redirectUri = redirectUri;
     IDmeWebVerify.clientSecret = clientSecret;
 
-    INSTANCE.storeApplicationNameFromContext(context);
+    INSTANCE.preferences = new IDmePreferences(context);
+    INSTANCE.preferences.storeApplicationNameFromContext(context);
   }
 
-  private IDmeWebVerify() {
-  }
-
-  private static final String APP_NAME_KEY_NAME = "IDmeWebVerify.applicationName";
-
-  private void storeApplicationNameFromContext(@NonNull Context context) {
-    loadPreferencesIfNeeded(context);
-    if (preferences == null) {
-      return;
-    }
-
-    ApplicationInfo applicationInfo = context.getApplicationInfo();
-    int stringId = applicationInfo.labelRes;
-    String appName = stringId == 0 ? applicationInfo.nonLocalizedLabel.toString() : context.getString(stringId);
-    preferences.edit()
-        .putString(APP_NAME_KEY_NAME, appName)
-        .apply();
-  }
-
-  @Nullable
-  String loadApplicationName(@NonNull Context context) {
-    loadPreferencesIfNeeded(context);
-    if (preferences == null) {
-      return null;
-    }
-
-    return preferences.getString(APP_NAME_KEY_NAME, null);
-  }
-
-  private void loadPreferencesIfNeeded(Context context) {
-    if (preferenceLoader == null) {
-      try {
-        preferenceLoader = new AsyncSharedPreferenceLoader(context);
-      } catch (Exception ex) {
-        // TODO: log
-        return;
-      }
-    }
-    if (preferences == null) {
-      preferences = preferenceLoader.get();
-    }
-  }
+  private IDmeWebVerify() {}
 
   public static IDmeWebVerify getInstance() {
     return INSTANCE;
+  }
+
+  @NonNull
+  public IDmePreferences getPreferences() {
+    return preferences;
   }
 
   /**

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/IDmeWebVerify.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/IDmeWebVerify.java
@@ -324,6 +324,7 @@ public final class IDmeWebVerify {
   /** Notifies the error to the appropriate listener */
   synchronized void notifyFailure(Throwable throwable) {
     if (currentState == null) {
+      Log.e(TAG, "Cannot notify failure due to there is not state set.", throwable);
       return;
     }
     switch (currentState) {

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/IDmeWebVerify.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/IDmeWebVerify.java
@@ -109,7 +109,7 @@ public final class IDmeWebVerify {
   }
 
   @NonNull
-  public IDmePreferences getPreferences() {
+  IDmePreferences getPreferences() {
     return preferences;
   }
 

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RedirectUriReceiverActivity.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RedirectUriReceiverActivity.java
@@ -6,6 +6,9 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.util.Log;
+import android.widget.Toast;
+
+import java.util.Locale;
 
 import me.id.webverifylib.exception.IDmeException;
 import me.id.webverifylib.listener.IDmeAccessTokenManagerListener;
@@ -32,6 +35,11 @@ public class RedirectUriReceiverActivity extends Activity {
     State currentState = IDmeWebVerify.getCurrentState();
 
     if (currentState == null) {
+      String appName = IDmeWebVerify.getInstance().loadApplicationName(this);
+      if (appName != null) {
+        String toast = String.format(Locale.getDefault(), getString(R.string.cannot_process_request_error_message), appName);
+        Toast.makeText(this, toast, Toast.LENGTH_LONG).show();
+      }
       IDmeWebVerify.getInstance().notifyFailure(new IDmeException("Activity was created but there is not an initialized process"));
       sendResult(RESULT_CANCELED);
       return;

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RedirectUriReceiverActivity.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RedirectUriReceiverActivity.java
@@ -32,7 +32,7 @@ public class RedirectUriReceiverActivity extends Activity {
     State currentState = IDmeWebVerify.getCurrentState();
 
     if (currentState == null) {
-      Log.w(IDmeWebVerify.TAG, "Activity was created but there is not an initialized process");
+      IDmeWebVerify.getInstance().notifyFailure(new IDmeException("Activity was created but there is not an initialized process"));
       sendResult(RESULT_CANCELED);
       return;
     }

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RedirectUriReceiverActivity.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RedirectUriReceiverActivity.java
@@ -1,6 +1,8 @@
 package me.id.webverifylib;
 
 import android.app.Activity;
+import android.app.PendingIntent;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.util.Log;
@@ -59,6 +61,12 @@ public class RedirectUriReceiverActivity extends Activity {
 
   private void sendResult(int resultCode) {
     setResult(resultCode);
+    try {
+      Intent intent = new Intent(this, IDmeCustomTabsActivity.class);
+      PendingIntent.getActivity(this, 0, intent, 0).send();
+    } catch (PendingIntent.CanceledException ex) {
+      ex.printStackTrace();
+    }
     finish();
   }
 }

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RedirectUriReceiverActivity.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RedirectUriReceiverActivity.java
@@ -35,7 +35,7 @@ public class RedirectUriReceiverActivity extends Activity {
     State currentState = IDmeWebVerify.getCurrentState();
 
     if (currentState == null) {
-      String appName = IDmeWebVerify.getInstance().loadApplicationName(this);
+      String appName = IDmeWebVerify.getInstance().getPreferences().loadApplicationName(this);
       if (appName != null) {
         String toast = String.format(Locale.getDefault(), getString(R.string.cannot_process_request_error_message), appName);
         Toast.makeText(this, toast, Toast.LENGTH_LONG).show();

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RedirectUriReceiverActivity.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/RedirectUriReceiverActivity.java
@@ -62,6 +62,9 @@ public class RedirectUriReceiverActivity extends Activity {
   private void sendResult(int resultCode) {
     setResult(resultCode);
     try {
+      // MOB-944: send an intent to the activity that started the browser. This is needed due to 
+      // RedirectUriReceiverActivity is opened in the browser's stack, so when this activity finishes,
+      // the result is that the browser will stay visible.
       Intent intent = new Intent(this, IDmeCustomTabsActivity.class);
       PendingIntent.getActivity(this, 0, intent, 0).send();
     } catch (PendingIntent.CanceledException ex) {

--- a/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/helper/CustomTabsHelper.java
+++ b/me.id.webverify/webverifylib/src/main/java/me/id/webverifylib/helper/CustomTabsHelper.java
@@ -35,7 +35,7 @@ public class CustomTabsHelper {
     if (packageName != null) {
       customTabsIntent.intent.setPackage(packageName);
     }
-    customTabsIntent.intent.setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY | Intent.FLAG_ACTIVITY_CLEAR_TOP
+    customTabsIntent.intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP
         | Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
     return customTabsIntent;
   }

--- a/me.id.webverify/webverifylib/src/main/res/values/strings.xml
+++ b/me.id.webverify/webverifylib/src/main/res/values/strings.xml
@@ -11,4 +11,5 @@
     <string name="unavailable">Unavailable</string>
     <string name="id_me_sdk_requires_internet_connection">ID.me Wallet requires an \n internet connection.</string>
     <string name="retry">Retry</string>
+    <string name="cannot_process_request_error_message">Request cannot be processed. Open application %1$s and try again, please.</string>
 </resources>


### PR DESCRIPTION
**NOTE FOR REVIEWERS**: just pay attention to the last commit. The other changes are included in the PR #43 && #44

## Description
In case the SDK is opened with an invalid state, it will notify back or log the error instead throwing an exception and making the app crash.

## Changes proposed in this request:
* --

![mob-1029](https://user-images.githubusercontent.com/4791678/33443995-c3b9b842-d5d7-11e7-8e6e-76e8d3168e60.gif)
